### PR TITLE
Fix Google Maps API key comment

### DIFF
--- a/src/utils/services/google-maps.service.ts
+++ b/src/utils/services/google-maps.service.ts
@@ -3,7 +3,8 @@ import axios from 'axios';
 
 @Injectable()
 export class GoogleMapsService {
-  private readonly apiKey = process.env.GOOGLE_MAPS_API_KEY; // Reemplaza con tu API Key
+  // Reads the API key from the `GOOGLE_MAPS_API_KEY` environment variable
+  private readonly apiKey = process.env.GOOGLE_MAPS_API_KEY;
   private readonly baseUrl = 'https://maps.googleapis.com/maps/api/distancematrix/json';
 
   async getDistanceMatrix(origins: string, destinations: string) {


### PR DESCRIPTION
## Summary
- clarify environment variable for Google Maps API key

## Testing
- `npx jest` *(fails: need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_684a1b26b0008328a43bc275c2b96feb