### PR TITLE
Update e2e test

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -4,7 +4,7 @@ import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
-describe('AppController (e2e)', () => {
+describe('Application Documentation (e2e)', () => {
   let app: INestApplication<App>;
 
   beforeEach(async () => {
@@ -16,10 +16,11 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /docs returns 200', () => {
+    return request(app.getHttpServer()).get('/docs').expect(200);
   });
 });

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,12 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "..",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1"
   }
 }


### PR DESCRIPTION
## Summary
- update the e2e spec to call `/docs`
- close the Nest app after tests
- tweak e2e Jest config for project paths

## Testing
- `npm run test:e2e` *(fails: Unable to connect to the database)*

------
https://chatgpt.com/codex/tasks/task_e_684a1c943dd48328a5789cc5bfba5075